### PR TITLE
Asciidoc formatting improvements

### DIFF
--- a/docs/modules/ROOT/pages/documentation/payara-server/server-configuration/certificate-management.adoc
+++ b/docs/modules/ROOT/pages/documentation/payara-server/server-configuration/certificate-management.adoc
@@ -8,10 +8,10 @@ A set of commands to provide integrated management of SSL & TLS certificates in 
 [[generate-self-signed-certificate]]
 == `generate-self-signed-certificate`
 
-*Usage*::
+Usage::
 `asadmin> generate-self-signed-certificate --target=instancename --listener=listenername --dn="DN1" --alternativenames="ALT1;ALT2;ALT3" alias`
 
-*Aim*::
+Aim::
 This command can generate a self-signed certificate for an instance, placing the resultant key pair in the target
 instance or listener's key and trust stores.
 
@@ -19,10 +19,9 @@ If the instance or listener is configured to use the default key and trust store
 the instance with the DAS (under the assumption the certificate has been added to the default key and trust store of
 the DAS), since any certificates added to the instance stores would be lost upon next synchronisation.
 
-*Note*::
-This command will not overwrite an entry already present in the key store with the same alias. In this scenario no certificate is generated and the command exits. In the case however where there is not an entry with the same alias in the key store but there is in the trust store, a certificate will be generated and the entry in the trust store will be overwritten.
+NOTE: This command will not overwrite an entry already present in the key store with the same alias. In this scenario no certificate is generated and the command exits. In the case however where there is not an entry with the same alias in the key store but there is in the trust store, a certificate will be generated and the entry in the trust store will be overwritten.
 
-[[command-options]]
+[[generate-self-signed-command-options]]
 === Command Options
 
 [cols="3,1,5,1,1",options="header"]
@@ -54,7 +53,7 @@ This command will not overwrite an entry already present in the key store with t
 |`--domaindir`
 |String
 |The path to the directory containing the target domain.
-|${installDir}/glassfish/domains
+|`${installDir}/glassfish/domains`
 |no
 
 |`--distinguishedname`, `--dn`
@@ -77,7 +76,7 @@ This command will not overwrite an entry already present in the key store with t
 
 |===
 
-[[example]]
+[[generate-self-signed-example]]
 === Example
 
 [source, shell]
@@ -92,17 +91,16 @@ test_cert
 [[generate-csr]]
 == `generate-csr`
 
-*Usage*::
+Usage::
 `asadmin> generate-csr --target=instancename --listener=listenername alias`
 
-*Aim*::
+Aim::
 This command can generate a certificate signing request (CSR) for an instance or listener's self-signed certificate,
-placing the resultant CSR file in ${installDir}/glassfish/tls, using the alias name as the file name.
+placing the resultant CSR file in `${installDir}/glassfish/tls`, using the alias name as the file name.
 
-*Note::
-This will overwrite a CSR with the same name already present in the ${installDir}/glassfish/tls directory.
+NOTE: This will overwrite a CSR with the same name already present in the `${installDir}/glassfish/tls` directory.
 
-[[command-options]]
+[[generate-csr-command-options]]
 === Command Options
 
 [cols="3,1,5,1,1",options="header"]
@@ -134,7 +132,7 @@ This will overwrite a CSR with the same name already present in the ${installDir
 |`--domaindir`
 |String
 |The path to the directory containing the target domain.
-|${installDir}/glassfish/domains
+|`${installDir}/glassfish/domains`
 |no
 
 |`--alias` (primary)
@@ -145,7 +143,7 @@ This will overwrite a CSR with the same name already present in the ${installDir
 
 |===
 
-[[example]]
+[[generate-csr-example]]
 === Example
 
 [source, shell]
@@ -156,10 +154,10 @@ asadmin> generate-csr --listener http-listener-2 --target Instance1 test_cert
 [[add-to-keystore]]
 == `add-to-keystore`
 
-*Usage*::
+Usage::
 `asadmin> add-to-keystore --target=instancename --listener=listenername --file /path/to/file alias`
 
-*Aim*::
+Aim::
 This command adds a certificate bundle (e.g. .p12 or .jks file) or certificate (e.g. .cert file) to the target instance
 or listener's key store using the provided alias.
 
@@ -167,10 +165,9 @@ If the instance or listener is configured to use the default key store, the comm
 the instance with the DAS (under the assumption the certificate has been added to the default key store of
 the DAS), since any certificates added to the instance stores would be lost upon next synchronisation.
 
-*Note*::
-This will overwrite an entry already present with the same alias.
+NOTE: This will overwrite an entry already present with the same alias.
 
-[[command-options]]
+[[add-to-keystore-command-options]]
 === Command Options
 
 [cols="3,1,5,1,1",options="header"]
@@ -202,7 +199,7 @@ This will overwrite an entry already present with the same alias.
 |`--domaindir`
 |String
 |The path to the directory containing the target domain.
-|${installDir}/glassfish/domains
+|`${installDir}/glassfish/domains`
 |no
 
 |`--file`
@@ -219,7 +216,7 @@ This will overwrite an entry already present with the same alias.
 
 |===
 
-[[example]]
+[[add-to-keystore-example]]
 === Example
 
 [source, shell]
@@ -230,10 +227,10 @@ asadmin> add-to-keystore --file /home/anon/Downloads/mycert.p12 mycert
 [[add-to-truststore]]
 == `add-to-truststore`
 
-*Usage*::
+Usage::
 `asadmin> add-to-truststore --target=instancename --listener=listenername --file /path/to/file alias`
 
-*Aim*::
+Aim::
 This command adds a certificate bundle (e.g. .p12 or .jks file) or certificate (e.g. .cert file) to the target instance
 or listener's trust store using the provided alias.
 
@@ -241,10 +238,9 @@ If the instance or listener is configured to use the default trust store, the co
 the instance with the DAS (under the assumption the certificate has been added to the default trust store of
 the DAS), since any certificates added to the instance stores would be lost upon next synchronisation.
 
-*Note*::
-This will overwrite an entry already present with the same alias.
+NOTE: This will overwrite an entry already present with the same alias.
 
-[[command-options]]
+[[add-to-truststore-command-options]]
 === Command Options
 
 [cols="3,1,5,1,1",options="header"]
@@ -276,7 +272,7 @@ This will overwrite an entry already present with the same alias.
 |`--domaindir`
 |String
 |The path to the directory containing the target domain.
-|${installDir}/glassfish/domains
+|`${installDir}/glassfish/domains`
 |no
 
 |`--file`
@@ -293,28 +289,28 @@ This will overwrite an entry already present with the same alias.
 
 |===
 
-[[example]]
+[[add-to-truststore-example]]
 === Example
 
 [source, shell]
 ----
-asadmin> add-to-keystore --file /home/anon/Downloads/mycert.p12 mycert
+asadmin> add-to-truststore --file /home/anon/Downloads/mycert.p12 mycert
 ----
 
 [[remove-from-keystore]]
 == `remove-from-keystore`
 
-*Usage*::
+Usage::
 `asadmin> remove-from-keystore --target=instancename --listener=listenername alias`
 
-*Aim*::
+Aim::
 This command removes a certificate from the target instance or listener's key store matching the provided alias.
 
 If the instance or listener is configured to use the default key store, the command will instead synchronise
 the instance with the DAS (under the assumption the certificate has been removed from the default key store of
 the DAS), since any certificates removed from the instance stores would be lost upon next synchronisation.
 
-[[command-options]]
+[[remove-from-keystore-command-options]]
 === Command Options
 
 [cols="3,1,5,1,1",options="header"]
@@ -346,7 +342,7 @@ the DAS), since any certificates removed from the instance stores would be lost 
 |`--domaindir`
 |String
 |The path to the directory containing the target domain.
-|${installDir}/glassfish/domains
+|`${installDir}/glassfish/domains`
 |no
 
 |`--alias` (primary)
@@ -357,7 +353,7 @@ the DAS), since any certificates removed from the instance stores would be lost 
 
 |===
 
-[[example]]
+[[remove-from-keystore-example]]
 === Example
 
 [source, shell]
@@ -368,17 +364,17 @@ asadmin> remove-from-keystore --domain_name production --target Instance1 --list
 [[remove-from-truststore]]
 == `remove-from-truststore`
 
-*Usage*::
+Usage::
 `asadmin> remove-from-truststore --target=instancename --listener=listenername alias`
 
-*Aim*::
+Aim::
 This command removes a certificate from the target instance or listener's trust store matching the provided alias.
 
 If the instance or listener is configured to use the default trust store, the command will instead synchronise
 the instance with the DAS (under the assumption the certificate has been removed from the default trust store of
 the DAS), since any certificates removed from the instance stores would be lost upon next synchronisation.
 
-[[command-options]]
+[[remove-from-truststore-command-options]]
 === Command Options
 
 [cols="3,1,5,1,1",options="header"]
@@ -410,7 +406,7 @@ the DAS), since any certificates removed from the instance stores would be lost 
 |`--domaindir`
 |String
 |The path to the directory containing the target domain.
-|${installDir}/glassfish/domains
+|`${installDir}/glassfish/domains`
 |no
 
 |`--alias` (primary)
@@ -421,7 +417,7 @@ the DAS), since any certificates removed from the instance stores would be lost 
 
 |===
 
-[[example]]
+[[remove-from-truststore-example]]
 === Example
 
 [source, shell]
@@ -433,17 +429,17 @@ asadmin> remove-from-truststore --domain_name production --target Instance1 --li
 [[remove-expired-certificates]]
 == `remove-expired-certificates`
 
-*Usage*::
+Usage::
 `asadmin> remove-expired-certificates --target=instancename --listener=listenername`
 
-*Aim*::
+Aim::
 This command removes all expired certificates from the target instance or listener's key and trust stores.
 
 If the instance or listener is configured to use the default trust store, the command will instead synchronise
 the instance with the DAS (under the assumption the certificate has been removed from the default trust store of
 the DAS), since any certificates removed from the instance stores would be lost upon next synchronisation.
 
-[[command-options]]
+[[remove-expired-certificates-command-options]]
 === Command Options
 
 [cols="3,1,5,1,1",options="header"]
@@ -475,12 +471,12 @@ the DAS), since any certificates removed from the instance stores would be lost 
 |`--domaindir`
 |String
 |The path to the directory containing the target domain.
-|${installDir}/glassfish/domains
+|`${installDir}/glassfish/domains`
 |no
 
 |===
 
-[[example]]
+[[remove-expired-certificates-example]]
 === Example
 
 [source, shell]


### PR DESCRIPTION
For PR https://github.com/payara/Payara-Enterprise-Documentation/pull/10

* Use NOTE admonition instead of Note::
* remove asterisks from Description:: because they are not needed, Asciidoc will format Description:: into _**Description**_ anyway
* added unique anchors for "Command Options" and "Examples" sections. Suppresses Asciidoc warnings and produces more human-friendly anchors

